### PR TITLE
Fix ecoli genome_id

### DIFF
--- a/src/services/general/src/yaml/api/1/endpoints.yaml
+++ b/src/services/general/src/yaml/api/1/endpoints.yaml
@@ -32,7 +32,7 @@ choice:
             PP: geneeb-feat
             QZ: genesb-feat
 
-        escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+        escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
             AK: gene-feat
             LL: gene-feat-names
             MO: trans-feat
@@ -68,7 +68,7 @@ choice:
             PP: geneeb-pc-fwd
             QZ: genesb-pc-fwd
 
-        escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+        escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
             AK: gene-pc-fwd
             LL: gene-pc-fwd-names
             MO: trans-pc-fwd
@@ -104,7 +104,7 @@ choice:
             PP: geneeb-pc-rev
             QZ: genesb-pc-rev
 
-        escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+        escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
             AK: gene-pc-rev
             LL: gene-pc-rev-names
             MO: trans-pc-rev
@@ -140,7 +140,7 @@ choice:
             PP: geneeb-other-fwd
             QZ: genesb-other-fwd
 
-        escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+        escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
             AK: gene-other-fwd
             LL: gene-other-fwd-names
             MO: trans-other-fwd
@@ -176,7 +176,7 @@ choice:
             PP: geneeb-other-rev
             QZ: genesb-other-rev
 
-        escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+        escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
             AK: gene-other-rev
             LL: gene-other-rev-names
             MO: trans-other-rev

--- a/src/services/general/src/yaml/api/2/endpoints.yaml
+++ b/src/services/general/src/yaml/api/2/endpoints.yaml
@@ -32,7 +32,7 @@ choice:
             PP: geneeb-feat
             QZ: genesb-feat
 
-        escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+        escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
             AK: gene-feat
             LL: gene-feat-names
             MO: trans-feat
@@ -68,7 +68,7 @@ choice:
             PP: geneeb-pc-fwd
             QZ: genesb-pc-fwd
 
-        escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+        escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
             AK: gene-pc-fwd
             LL: gene-pc-fwd-names
             MO: trans-pc-fwd
@@ -104,7 +104,7 @@ choice:
             PP: geneeb-pc-rev
             QZ: genesb-pc-rev
 
-        escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+        escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
             AK: gene-pc-rev
             LL: gene-pc-rev-names
             MO: trans-pc-rev
@@ -140,7 +140,7 @@ choice:
             PP: geneeb-other-fwd
             QZ: genesb-other-fwd
 
-        escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+        escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
             AK: gene-other-fwd
             LL: gene-other-fwd-names
             MO: trans-other-fwd
@@ -176,7 +176,7 @@ choice:
             PP: geneeb-other-rev
             QZ: genesb-other-rev
 
-        escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+        escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
             AK: gene-other-rev
             LL: gene-other-rev-names
             MO: trans-other-rev

--- a/src/services/general/src/yaml/api/3/endpoints.yaml
+++ b/src/services/general/src/yaml/api/3/endpoints.yaml
@@ -35,7 +35,7 @@ choice:
                 PP: geneeb-feat
                 QZ: genesb-feat
 
-            escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+            escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
                 AK: gene-feat
                 LL: gene-feat-names
                 MO: trans-feat
@@ -80,7 +80,7 @@ choice:
                 PP: geneeb-pc-fwd
                 QZ: genesb-pc-fwd
 
-            escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+            escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
                 AK: gene-pc-fwd
                 LL: gene-pc-fwd-names
                 MO: trans-pc-fwd
@@ -117,7 +117,7 @@ choice:
                 PP: geneeb-pc-rev
                 QZ: genesb-pc-rev
 
-            escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+            escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
                 AK: gene-pc-rev
                 LL: gene-pc-rev-names
                 MO: trans-pc-rev
@@ -154,7 +154,7 @@ choice:
                 PP: geneeb-other-fwd
                 QZ: genesb-other-fwd
 
-            escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+            escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
                 AK: gene-other-fwd
                 LL: gene-other-fwd-names
                 MO: trans-other-fwd
@@ -191,7 +191,7 @@ choice:
                 PP: geneeb-other-rev
                 QZ: genesb-other-rev
 
-            escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+            escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
                 AK: gene-other-rev
                 LL: gene-other-rev-names
                 MO: trans-other-rev

--- a/src/services/general/src/yaml/endpoints.yaml
+++ b/src/services/general/src/yaml/endpoints.yaml
@@ -32,7 +32,7 @@ choice:
             PP: geneeb-feat
             QZ: genesb-feat
 
-        escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+        escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
             AK: gene-feat
             LL: gene-feat-names
             MO: trans-feat
@@ -68,7 +68,7 @@ choice:
             PP: geneeb-pc-fwd
             QZ: genesb-pc-fwd
 
-        escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+        escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
             AK: gene-pc-fwd
             LL: gene-pc-fwd-names
             MO: trans-pc-fwd
@@ -104,7 +104,7 @@ choice:
             PP: geneeb-pc-rev
             QZ: genesb-pc-rev
 
-        escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+        escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
             AK: gene-pc-rev
             LL: gene-pc-rev-names
             MO: trans-pc-rev
@@ -140,7 +140,7 @@ choice:
             PP: geneeb-other-fwd
             QZ: genesb-other-fwd
 
-        escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+        escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
             AK: gene-other-fwd
             LL: gene-other-fwd-names
             MO: trans-other-fwd
@@ -176,7 +176,7 @@ choice:
             PP: geneeb-other-rev
             QZ: genesb-other-rev
 
-        escherichia_coli_str_k_12_substr_mg1655_GCA_000005845.2:
+        escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845.2:
             AK: gene-other-rev
             LL: gene-other-rev-names
             MO: trans-other-rev


### PR DESCRIPTION
**Problem**
Production_name for e.coli has changed
 from
escherichia_coli_str_k_12_substr_mg1655
to
escherichia_coli_str_k_12_substr_mg1655_gca_000005845
and this causes to change the genome_id 
from
escherichia_coli_str_k_12_substr_mg1655_GCA_000005845_2
to
escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2

This breaks 2020.ensembl.org while viewing e.coli on GB and EV

**Resolution**
Updated genome_ids in YAML and updated test cases
update common_files/genome_id_info.yaml with new genome_id

It is updated here
/nfs/services/enswbsites/newsite/dev/genome_browser/4/common_files/genome_id_info.yaml
Once this PR gets merged update config map to use updated file for all environment 
/nfs/services/enswbsites/newsite/{staging,internal,prod}/genome_browser/4/common_files/genome_id_info.yaml

**Review App**
(You need to be connected to VPN to access review app)
http://fix-ecoli.review.ensembl.org/api/browser/config

**Other Actions:**
This should  go live with genome-search fix 
https://github.com/Ensembl/ensembl-2020-genome-search/pull/27
https://github.com/Ensembl/ensembl-client/pull/472

**JIRA**
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1026